### PR TITLE
fix width (for Mozila) of input for verification code entering

### DIFF
--- a/src/routes/forgot-password/index.js
+++ b/src/routes/forgot-password/index.js
@@ -127,7 +127,6 @@ class EditProfile extends Component {
 				
 				{ this.state.codeSent && (
 					
-					
 					<div className={style.userDetails}>
 						{ !this.state.codeVerified && (
 							<div className={style.codeMessage}>

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -157,12 +157,12 @@ button {
 		display: flex;
 		justify-content: space-between;
 		> input {
-			flex-basis: 23%;
+			//flex-basis: 23%;
+			width: 23%;
 			height: 60px;
 			text-align: center;
 			font-size: 30px;
 		}
-		
 		
 	}
 	


### PR DESCRIPTION
Some problems with flex in Mozila
Before:
![before](https://user-images.githubusercontent.com/26123276/45740767-a8a0d500-bbfe-11e8-9c4b-edbb1165ae77.png)
After:
![after](https://user-images.githubusercontent.com/26123276/45740784-b2c2d380-bbfe-11e8-8e37-29a100062799.png)
